### PR TITLE
Switch AMP analytics to GA4

### DIFF
--- a/index.html
+++ b/index.html
@@ -279,11 +279,16 @@
     
     <!-- Optional Files -->
     <!-- Google Analytics -->
-    <amp-analytics type="googleanalytics">
+    <amp-analytics type="gtag" data-credentials="include">
       <script type="application/json">
         {
           "vars": {
-            "account": "UA-30145059-32"
+            "gtag_id": "G-Q4N7BF6JVG",
+            "config": {
+              "G-Q4N7BF6JVG": {
+                "groups": "default"
+              }
+            }
           },
           "triggers": {
             "default pageview": {


### PR DESCRIPTION
## Summary
- replace the legacy Universal Analytics AMP configuration with GA4 gtag settings using measurement ID G-Q4N7BF6JVG
- retain the default pageview trigger on document visibility while using GA4 configuration

## Testing
- not run (not requested)
